### PR TITLE
Added instructions for Activation

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,6 +29,7 @@ After integrating Proximity Kit for iOS or/and Android by following the steps de
 You are done! Next time your app syncs with Proximity Kit, Status Kit will be automatically enabled.
 
 <b> Activating Director After Campaign Kit Integration </b>
+<strong> TBD </strong>
 
 ## Public API Resources
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,6 +13,7 @@ located and alerts you when they need attention.
 To begin to monitor beacon status in your Director Dashboard, integrate our Campaign Kit or Proximity Kit SDK with your mobile app, and then follow the steps below:
 
 <b> Activating Director After Proximity Kit Integration </b>
+<br>
 After integrating Proximity Kit for iOS or/and Android by following the steps detailed <a href= "https://proximitykit.radiusnetworks.com/docs/overview"> here </a>, follow the steps below to activate Director and begin to monitor the health status of every beacon in your fleet.
 
 1. Login to your Radius Networks <a href="https://account.radiusnetworks.com"> Account</a> and click on "Team Settings".

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,7 +29,7 @@ After integrating Proximity Kit for iOS or/and Android by following the steps de
 You are done! Next time your app syncs with Proximity Kit, Status Kit will be automatically enabled.
 
 <b> Activating Director After Campaign Kit Integration </b> <br>
-<strong> TBD </strong>
+Please contact us at support@radiusnetworks.com for more information. We will work with you to get Director up and run, upon integration with Campaign Kit.
 
 ## Public API Resources
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@ of all beacons, manage the metadata that helps you identify where they are
 located and alerts you when they need attention.
 
 <h2> Activating Director </h1>
-To begin to monitor beacon status in your Director Dashboard, integrate our Campaign Kit or Proximity Kit SDK with your mobile app, and then follow the steps below:
+To begin to monitor beacon status in your Director Dashboard, integrate our <a href="https://campaignkit.radiusnetworks.com/docs/overview">Campaign Kit</a> or <a href= "https://proximitykit.radiusnetworks.com/docs/overview">Proximity Kit</a> SDK with your mobile app, and then follow the steps below:
 
 <b> Activating Director After Proximity Kit Integration </b>
 <br>

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,7 +28,7 @@ After integrating Proximity Kit for iOS or/and Android by following the steps de
 
 You are done! Next time your app syncs with Proximity Kit, Status Kit will be automatically enabled.
 
-<b> Activating Director After Campaign Kit Integration </b>
+<b> Activating Director After Campaign Kit Integration </b> <br>
 <strong> TBD </strong>
 
 ## Public API Resources

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,6 +9,26 @@ Director provides a scalable, cloud-based system where you can view the status
 of all beacons, manage the metadata that helps you identify where they are
 located and alerts you when they need attention.
 
+<h2> Activating Director </h1>
+To begin to monitor beacon status in your Director Dashboard, integrate our Campaign Kit or Proximity Kit SDK with your mobile app, and then follow the steps below:
+
+<b> Activating Director After Proximity Kit Integration </b>
+After integrating Proximity Kit for iOS or/and Android by following the steps detailed <a href= "https://proximitykit.radiusnetworks.com/docs/overview" here </a>, follow the steps below to activate Director and begin to monitor the health status of every beacon in your fleet.
+
+1. Login to your Radius Networks <a href="https://account.radiusnetworks.com"> Account</a> and click on "Team Settings".
+2. On the "Team Settings" page, click on "New Team", enter the "Team Name" and click on "create".
+3. From the account page, click on "Director", and select "Settings" from under the new team you just created.
+4. Under "SDK Access Tokens", click on "Generate Token".
+5. Copy the newly generated token.
+6. Go back to the accounts home page and click on "Proximity Kit".
+7. On the Proximity Kit page, click on "Create New Kit".
+8. Enter you "Kit name", ensure "Explicit Beacon Monitoring" is checked and paste the "Status Token" you copied from Director.
+9. Click save.
+
+You are done! Next time your app syncs with Proximity Kit, Status Kit will be automatically enabled.
+
+<b> Activating Director After Campaign Kit Integration </b>
+
 ## Public API Resources
 
 The [Director API](api) provides programmable access to the rich content

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ located and alerts you when they need attention.
 To begin to monitor beacon status in your Director Dashboard, integrate our Campaign Kit or Proximity Kit SDK with your mobile app, and then follow the steps below:
 
 <b> Activating Director After Proximity Kit Integration </b>
-After integrating Proximity Kit for iOS or/and Android by following the steps detailed <a href= "https://proximitykit.radiusnetworks.com/docs/overview" here </a>, follow the steps below to activate Director and begin to monitor the health status of every beacon in your fleet.
+After integrating Proximity Kit for iOS or/and Android by following the steps detailed <a href= "https://proximitykit.radiusnetworks.com/docs/overview"> here </a>, follow the steps below to activate Director and begin to monitor the health status of every beacon in your fleet.
 
 1. Login to your Radius Networks <a href="https://account.radiusnetworks.com"> Account</a> and click on "Team Settings".
 2. On the "Team Settings" page, click on "New Team", enter the "Team Name" and click on "create".


### PR DESCRIPTION
@csexton @cupakromer 
Added some more info regarding activating Director. This was added in support of the changes we made to our emails that go out to customers who buy beacons. The idea is to give the customers the information they need to successfully activate Director, based on the SDK they integrate with.
